### PR TITLE
Set config to detailed error message

### DIFF
--- a/RWSettings.php
+++ b/RWSettings.php
@@ -583,7 +583,7 @@ $wgDBerrorLog = '/var/log/mw/dberror.log';
 
 $wgNamespaceRobotPolicies = array( NS_USER => 'noindex', NS_USER_TALK => 'noindex' );
 
-$wgShowExceptionDetails = false;
+$wgShowExceptionDetails = true;
 $wgUseSquid = true;
 $wgSquidServers = array('45.33.90.21', '127.0.0.1');
 $wgDisableCounters = true;


### PR DESCRIPTION
@awbs 
[Our broken Special Pages](https://rationalwiki.org/wiki/RationalWiki:Technical_support#Special:ProtectedPages_is_broken_.28sticky.29) thing.

I think we will be better able to solve it with a more detailed error message.