### PR TITLE
Draft and draft talk no longer indexed

### DIFF
--- a/RWSettings.php
+++ b/RWSettings.php
@@ -581,7 +581,7 @@ foreach ( $logGroups as $logGroup ) {
 }
 $wgDBerrorLog = '/var/log/mw/dberror.log';
 
-$wgNamespaceRobotPolicies = array( NS_USER => 'noindex', NS_USER_TALK => 'noindex' );
+$wgNamespaceRobotPolicies = array( NS_DRAFT => 'noindex', NS_DRAFT_TALK => 'noindex', NS_USER => 'noindex', NS_USER_TALK => 'noindex' );
 
 $wgShowExceptionDetails = true;
 $wgShowHostnames = true;


### PR DESCRIPTION
The draft and draft talk namespaces shouldn’t be indexed by search engines. Look at https://rationalwiki.org/wiki/Template:Draft and you’ll see this already site policy, this is a cleaner way of implementing it and includes talk pages.

Discussion on whether other namespaces, such as essay or debate, should be noindexed as well is ongoing at RW:technical support.